### PR TITLE
Schema changes for readiness/liveness

### DIFF
--- a/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
@@ -81,6 +81,68 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                 functions: null);
             var portsProperty = new TypeProperty("ports", portsType, TypePropertyFlags.None);
 
+            var headersType = new ObjectType(
+                name: "headers",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: Array.Empty<TypeProperty>(),
+                additionalPropertiesType: LanguageConstants.String,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
+
+            var httpGet = new ObjectType(
+                name: "httpGet",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: new TypeProperty[] {
+                    new TypeProperty("containerPort", LanguageConstants.Int, TypePropertyFlags.Required),
+                    new TypeProperty("path", LanguageConstants.String, TypePropertyFlags.Required),
+                    new TypeProperty("headers", headersType, TypePropertyFlags.None),
+                    new TypeProperty("kind", new StringLiteralType("httpGet"), TypePropertyFlags.Required),
+                    new TypeProperty("initialDelaySeconds", LanguageConstants.Int, TypePropertyFlags.None),
+                    new TypeProperty("failureThreshold", LanguageConstants.Int, TypePropertyFlags.None),
+                    new TypeProperty("periodSeconds", LanguageConstants.Int, TypePropertyFlags.None),
+                },
+                additionalPropertiesType: null,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
+
+            var tcp = new ObjectType(
+                name: "tcp",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: new TypeProperty[] {
+                    new TypeProperty("containerPort", LanguageConstants.Int, TypePropertyFlags.Required),
+                    new TypeProperty("kind", new StringLiteralType("tcp"), TypePropertyFlags.Required),
+                    new TypeProperty("initialDelaySeconds", LanguageConstants.Int, TypePropertyFlags.None),
+                    new TypeProperty("failureThreshold", LanguageConstants.Int, TypePropertyFlags.None),
+                    new TypeProperty("periodSeconds", LanguageConstants.Int, TypePropertyFlags.None),
+                },
+                additionalPropertiesType: null,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
+
+            var exec = new ObjectType(
+                name: "exec",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: new TypeProperty[] {
+                    new TypeProperty("command", LanguageConstants.String, TypePropertyFlags.Required),
+                    new TypeProperty("kind", new StringLiteralType("exec"), TypePropertyFlags.Required),
+                    new TypeProperty("initialDelaySeconds", LanguageConstants.Int, TypePropertyFlags.None),
+                    new TypeProperty("failureThreshold", LanguageConstants.Int, TypePropertyFlags.None),
+                    new TypeProperty("periodSeconds", LanguageConstants.Int, TypePropertyFlags.None),
+                },
+                additionalPropertiesType: null,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
+
+            var healthProbeType = new DiscriminatedObjectType(
+                name: "healthProbe",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                discriminatorKey: "kind",
+                unionMembers: new ITypeReference[]{httpGet, tcp, exec}
+                );
+            
+            var readinessProperty = new TypeProperty("readiness", healthProbeType, TypePropertyFlags.None, "Readiness check");
+            var livessProperty = new TypeProperty("liveness", healthProbeType, TypePropertyFlags.None, "Liveness check");
+
             var imageProperty = new TypeProperty("image", LanguageConstants.String, TypePropertyFlags.Required);
             var containerType = new ObjectType(
                 "container",
@@ -90,6 +152,8 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                     imageProperty,
                     envProperty,
                     portsProperty,
+                    readinessProperty,
+                    livessProperty
                 },
                 additionalPropertiesType: LanguageConstants.Any,
                 additionalPropertiesFlags: TypePropertyFlags.None);

--- a/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
@@ -93,13 +93,13 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                 name: "httpGet",
                 validationFlags: TypeSymbolValidationFlags.Default,
                 properties: new TypeProperty[] {
-                    new TypeProperty("containerPort", LanguageConstants.Int, TypePropertyFlags.Required),
-                    new TypeProperty("path", LanguageConstants.String, TypePropertyFlags.Required),
-                    new TypeProperty("headers", headersType, TypePropertyFlags.None),
-                    new TypeProperty("kind", new StringLiteralType("httpGet"), TypePropertyFlags.Required),
-                    new TypeProperty("initialDelaySeconds", LanguageConstants.Int, TypePropertyFlags.None),
-                    new TypeProperty("failureThreshold", LanguageConstants.Int, TypePropertyFlags.None),
-                    new TypeProperty("periodSeconds", LanguageConstants.Int, TypePropertyFlags.None),
+                    new TypeProperty("containerPort", LanguageConstants.Int, TypePropertyFlags.Required, "The listening port number"),
+                    new TypeProperty("path", LanguageConstants.String, TypePropertyFlags.Required, "The route to make the HTTP request on"),
+                    new TypeProperty("headers", headersType, TypePropertyFlags.None, "Custom HTTP headers to add to the get request"),
+                    new TypeProperty("kind", new StringLiteralType("httpGet"), TypePropertyFlags.Required, "Health probe kind"),
+                    new TypeProperty("initialDelaySeconds", LanguageConstants.Int, TypePropertyFlags.None, "Initial delay in seconds before probing for readiness/liveness"),
+                    new TypeProperty("failureThreshold", LanguageConstants.Int, TypePropertyFlags.None, "Threshold number of times the probe fails after which a failure would be reported"),
+                    new TypeProperty("periodSeconds", LanguageConstants.Int, TypePropertyFlags.None, "Interval for the readiness/liveness probe in seconds"),
                 },
                 additionalPropertiesType: null,
                 additionalPropertiesFlags: TypePropertyFlags.None,
@@ -109,11 +109,11 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                 name: "tcp",
                 validationFlags: TypeSymbolValidationFlags.Default,
                 properties: new TypeProperty[] {
-                    new TypeProperty("containerPort", LanguageConstants.Int, TypePropertyFlags.Required),
-                    new TypeProperty("kind", new StringLiteralType("tcp"), TypePropertyFlags.Required),
-                    new TypeProperty("initialDelaySeconds", LanguageConstants.Int, TypePropertyFlags.None),
-                    new TypeProperty("failureThreshold", LanguageConstants.Int, TypePropertyFlags.None),
-                    new TypeProperty("periodSeconds", LanguageConstants.Int, TypePropertyFlags.None),
+                    new TypeProperty("containerPort", LanguageConstants.Int, TypePropertyFlags.Required, "The listening port number"),
+                    new TypeProperty("kind", new StringLiteralType("tcp"), TypePropertyFlags.Required, "Health probe kind"),
+                    new TypeProperty("initialDelaySeconds", LanguageConstants.Int, TypePropertyFlags.None, "Initial delay in seconds before probing for readiness/liveness"),
+                    new TypeProperty("failureThreshold", LanguageConstants.Int, TypePropertyFlags.None, "Threshold number of times the probe fails after which a failure would be reported"),
+                    new TypeProperty("periodSeconds", LanguageConstants.Int, TypePropertyFlags.None, "Interval for the readiness/liveness probe in seconds"),
                 },
                 additionalPropertiesType: null,
                 additionalPropertiesFlags: TypePropertyFlags.None,
@@ -123,11 +123,11 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                 name: "exec",
                 validationFlags: TypeSymbolValidationFlags.Default,
                 properties: new TypeProperty[] {
-                    new TypeProperty("command", LanguageConstants.String, TypePropertyFlags.Required),
-                    new TypeProperty("kind", new StringLiteralType("exec"), TypePropertyFlags.Required),
-                    new TypeProperty("initialDelaySeconds", LanguageConstants.Int, TypePropertyFlags.None),
-                    new TypeProperty("failureThreshold", LanguageConstants.Int, TypePropertyFlags.None),
-                    new TypeProperty("periodSeconds", LanguageConstants.Int, TypePropertyFlags.None),
+                    new TypeProperty("command", LanguageConstants.String, TypePropertyFlags.Required, "Command to execute to probe readiness/liveness"),
+                    new TypeProperty("kind", new StringLiteralType("exec"), TypePropertyFlags.Required, "Health probe kind"),
+                    new TypeProperty("initialDelaySeconds", LanguageConstants.Int, TypePropertyFlags.None, "Initial delay in seconds before probing for readiness/liveness"),
+                    new TypeProperty("failureThreshold", LanguageConstants.Int, TypePropertyFlags.None, "Threshold number of times the probe fails after which a failure would be reported"),
+                    new TypeProperty("periodSeconds", LanguageConstants.Int, TypePropertyFlags.None, "Interval for the readiness/liveness probe in seconds"),
                 },
                 additionalPropertiesType: null,
                 additionalPropertiesFlags: TypePropertyFlags.None,
@@ -140,8 +140,8 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                 unionMembers: new ITypeReference[]{httpGet, tcp, exec}
                 );
             
-            var readinessProperty = new TypeProperty("readiness", healthProbeType, TypePropertyFlags.None, "Readiness check");
-            var livessProperty = new TypeProperty("liveness", healthProbeType, TypePropertyFlags.None, "Liveness check");
+            var readinessProperty = new TypeProperty("readinessProbe", healthProbeType, TypePropertyFlags.None, "Readiness health probe");
+            var livessProperty = new TypeProperty("livenessProbe", healthProbeType, TypePropertyFlags.None, "Liveness health probe");
 
             var imageProperty = new TypeProperty("image", LanguageConstants.String, TypePropertyFlags.Required);
             var containerType = new ObjectType(


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
