### PR TITLE
schema changes for volumes

### DIFF
--- a/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
@@ -292,7 +292,7 @@ namespace Bicep.Core.TypeSystem.Radius.V3
 
             return new ComponentData()
             {
-                Type = new ThreePartType(null, "Volume", RadiusResources.CategoryComponent),
+                Type = new ThreePartType(null, "Volume", ""),
                 Properties =
                 {
                     new TypeProperty("kind", configKindType, TypePropertyFlags.Required),

--- a/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
@@ -85,9 +85,9 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                 name: "ephemeral",
                 validationFlags: TypeSymbolValidationFlags.Default,
                 properties: new TypeProperty[] {
-                    new TypeProperty("kind", new StringLiteralType("ephemeral"), TypePropertyFlags.Required),
-                    new TypeProperty("mountPath", LanguageConstants.String, TypePropertyFlags.Required),
-                    new TypeProperty("managedStore", UnionType.Create(new StringLiteralType("memory"), new StringLiteralType("disk")), TypePropertyFlags.None),
+                    new TypeProperty("kind", new StringLiteralType("ephemeral"), TypePropertyFlags.Required, "Volume Kind"),
+                    new TypeProperty("mountPath", LanguageConstants.String, TypePropertyFlags.Required, "The path where the volume is mounted"),
+                    new TypeProperty("managedStore", UnionType.Create(new StringLiteralType("memory"), new StringLiteralType("disk")), TypePropertyFlags.Required, "Backing store for the ephemeral volume"),
                 },
                 additionalPropertiesType: null,
                 additionalPropertiesFlags: TypePropertyFlags.None,
@@ -97,21 +97,29 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                 name: "persistent",
                 validationFlags: TypeSymbolValidationFlags.Default,
                 properties: new TypeProperty[] {
-                    new TypeProperty("kind", new StringLiteralType("persistent"), TypePropertyFlags.Required),
-                    new TypeProperty("mountPath", LanguageConstants.String, TypePropertyFlags.Required),
-                    new TypeProperty("source", LanguageConstants.String, TypePropertyFlags.Required),
-                    new TypeProperty("rbac", UnionType.Create(new StringLiteralType("read"), new StringLiteralType("write")), TypePropertyFlags.None),
+                    new TypeProperty("kind", new StringLiteralType("persistent"), TypePropertyFlags.Required, "Volume kind"),
+                    new TypeProperty("mountPath", LanguageConstants.String, TypePropertyFlags.Required, "The path where the volume is mounted"),
+                    new TypeProperty("source", LanguageConstants.String, TypePropertyFlags.Required, "The source of the volume"),
+                    new TypeProperty("rbac", UnionType.Create(new StringLiteralType("read"), new StringLiteralType("write")), TypePropertyFlags.None, "Container read/write access to the volume"),
                 },
                 additionalPropertiesType: null,
                 additionalPropertiesFlags: TypePropertyFlags.None,
                 functions: null);
 
-            var volumesType = new DiscriminatedObjectType(
-                name: "volumes",
+            var volumeItemType = new DiscriminatedObjectType(
+                name: "volume",
                 validationFlags: TypeSymbolValidationFlags.Default,
                 discriminatorKey: "kind",
                 unionMembers: new ITypeReference[]{ephemeralVolume, persistentVolume}
                 );
+
+            var volumesType = new ObjectType(
+                name: "volumes",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: Array.Empty<TypeProperty>(),
+                additionalPropertiesType: volumeItemType,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
             var volumesProperty = new TypeProperty("volumes", volumesType, TypePropertyFlags.None);
 
             var imageProperty = new TypeProperty("image", LanguageConstants.String, TypePropertyFlags.Required);

--- a/src/Bicep.Core/TypeSystem/Radius/V3/KnownTypes.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/KnownTypes.cs
@@ -73,6 +73,7 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                 KnownComponents.MakeKeyVault(),
                 KnownComponents.MakeServiceBusQueue(),
                 KnownComponents.MakeRedis(),
+                KnownComponents.MakeVolume(),
             };
 
             return components.Select(s => MakeComponentType(provider, s));


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
