### PR TITLE
changes for azure keyvault csi driver

### DIFF
--- a/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
@@ -653,19 +653,92 @@ Resources provided by the developer will not be modified or deleted by Radius. U
 
         public static ComponentData MakeVolume()
         {
-            var configKindType = new UnionType(
-                "volume kind",
-                ImmutableArray.Create<ITypeReference>(new StringLiteralType("azure.com.fileshare")));
+            var encodingType = new UnionType("encoding", ImmutableArray.Create<ITypeReference>(new StringLiteralType("utf-8"), new StringLiteralType("hex"), new StringLiteralType("base64")));
+            var formatType = new UnionType("format", ImmutableArray.Create<ITypeReference>(new StringLiteralType("pfx")));
+            var valueType = new UnionType("value", ImmutableArray.Create<ITypeReference>(new StringLiteralType("certificate"), new StringLiteralType("publickey"), new StringLiteralType("privatekey")));
+
+            var secretItemType = new ObjectType(
+                name: "secret",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: new TypeProperty[] {
+                    new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required, "Name of the Azure KeyVault secret"),
+                    new TypeProperty("version", LanguageConstants.String, TypePropertyFlags.None, "Version of the secret. Latest by default"),
+                    new TypeProperty("encoding", encodingType, TypePropertyFlags.None, "Encoding format of the secret"),
+                },
+                additionalPropertiesType: null,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
+
+            var secrets = new ObjectType(
+                name: "secrets",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: Array.Empty<TypeProperty>(),
+                additionalPropertiesType: secretItemType,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
+
+            var keysItemType = new ObjectType(
+                name: "key",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: new TypeProperty[] {
+                    new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required, "Name of the Azure KeyVault key"),
+                    new TypeProperty("version", LanguageConstants.String, TypePropertyFlags.None, "Version of the key. Latest by default"),
+                    },
+                additionalPropertiesType: null,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
+
+            var keys = new ObjectType(
+                name: "keys",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: Array.Empty<TypeProperty>(),
+                additionalPropertiesType: keysItemType,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
+
+            var certificatesItemType = new ObjectType(
+                name: "certificates",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: new TypeProperty[] {
+                    new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required, "Name of the Azure KeyVault certificate"),
+                    new TypeProperty("version", LanguageConstants.String, TypePropertyFlags.None, "Version of the certificate. Latest by default"),
+                    new TypeProperty("encoding", encodingType, TypePropertyFlags.None, "Encoding format of the certificate"),
+                    new TypeProperty("format", formatType, TypePropertyFlags.None, "Format of the certificate"),
+                    new TypeProperty("value", valueType, TypePropertyFlags.Required,"Value to be downloaded from the Azure KeyVault"),
+                    },
+                additionalPropertiesType: null,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
+
+            var certificates = new ObjectType(
+                name: "certificates",
+                validationFlags: TypeSymbolValidationFlags.Default,
+                properties: Array.Empty<TypeProperty>(),
+                additionalPropertiesType: certificatesItemType,
+                additionalPropertiesFlags: TypePropertyFlags.None,
+                functions: null);
+
+
+            var persistentVolumeKindType = new UnionType(
+                "persistent volume kind",
+                ImmutableArray.Create<ITypeReference>(
+                    new StringLiteralType("azure.com.fileshare"),
+                    new StringLiteralType("azure.com.keyvault")
+                )
+            );
 
             return new ComponentData()
             {
-                Type = new ThreePartType(null, "Volume", ""),
+                Type = new ThreePartType(null, "Volume", RadiusResources.CategoryComponent),
                 Properties =
                 {
-                    new TypeProperty("kind", configKindType, TypePropertyFlags.Required),
-                    new TypeProperty("managed", LanguageConstants.Bool, TypePropertyFlags.None),
-                    new TypeProperty("resource", LanguageConstants.String, TypePropertyFlags.None),
-                },
+                    new TypeProperty("managed", LanguageConstants.Bool, TypePropertyFlags.None, "Managed by Radius"),
+                    new TypeProperty("resource", LanguageConstants.String, TypePropertyFlags.None, "Resource ID for user managed resource"),
+                    new TypeProperty("kind", persistentVolumeKindType, TypePropertyFlags.Required, "Persistent volume kind"),
+                    new TypeProperty("secrets", secrets, TypePropertyFlags.None, "Secrets from the Azure KeyVault to be mounted"),
+                    new TypeProperty("keys", keys, TypePropertyFlags.None, "Keys from the Azure KeyVault to be mounted"),
+                    new TypeProperty("certificates", certificates, TypePropertyFlags.None, "Certificates from the Azure KeyVault to be mounted")
+                }
             };
         }
     }


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
