### PR TITLE
Add K8s extension fields for MongoDB

### DIFF
--- a/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs
@@ -209,6 +209,8 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                         properties: new []
                         {
                             new TypeProperty("connectionString", LanguageConstants.String, TypePropertyFlags.WriteOnly),
+                            new TypeProperty("username", LanguageConstants.String, TypePropertyFlags.WriteOnly),
+                            new TypeProperty("password", LanguageConstants.String, TypePropertyFlags.WriteOnly),
                         },
                         additionalPropertiesType: null,
                         additionalPropertiesFlags: TypePropertyFlags.None),
@@ -216,7 +218,11 @@ namespace Bicep.Core.TypeSystem.Radius.V3
             },
             Values =
             {
+                new BindingValue("host"),
+                new BindingValue("port"),
+                new BindingValue("username", secret: true),
                 new BindingValue("connectionString", secret: true),
+                new BindingValue("password", secret: true),
             },
         };
 


### PR DESCRIPTION
Part of https://github.com/Azure/radius/issues/1198.

I am not sure we will need all of these. After we tie this to our JSON schema we can prune this down further.