### PR TITLE
Add RBAC support for non-radius azure resources

### DIFF
--- a/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs
@@ -288,6 +288,11 @@ namespace Bicep.Core.TypeSystem.Radius.V3
             },
         };
 
+        public static readonly BindingData BindingDataKindAzure = new BindingData()
+        {
+            Type = new ThreePartType(null, "azure", String.Empty),
+        };
+
         public static readonly BindingData[] AllBindingData = new BindingData[]
         {
             BindingDataDaprHttp,
@@ -301,6 +306,7 @@ namespace Bicep.Core.TypeSystem.Radius.V3
             BindingDataRabbitMQ,
             BindingDataServiceBusQueue,
             BindingDataSQL,
+            BindingDataKindAzure,
         };
 
         public static readonly IEnumerable<BindingData> RouteBindingData = AllBindingData.Where(b => b.IsRoute);

--- a/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
@@ -9,6 +9,9 @@ namespace Bicep.Core.TypeSystem.Radius.V3
 {
     public static class KnownComponents
     {
+        var roleType = new TypedArrayType(
+                itemReference: LanguageConstants.String,
+                validationFlags: TypeSymbolValidationFlags.Default);
         public class ComponentData
         {
             public ThreePartType Type { get; set; } = default!;
@@ -33,6 +36,7 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                         {
                             new TypeProperty("kind", new StringLiteralType(b.Type.FormatKind()), TypePropertyFlags.Required, "The kind of connection"),
                             new TypeProperty("source", LanguageConstants.String, TypePropertyFlags.Required, "The source of the connection"),
+                            new TypeProperty("role", roleType, TypePropertyFlags.None, "RBAC configuration to be applied on the connection"),
                         },
                         additionalPropertiesType: null,
                         additionalPropertiesFlags: TypePropertyFlags.None,
@@ -247,6 +251,7 @@ In this example the `web` port documents that the container is listening on port
                         {
                             new TypeProperty("kind", new StringLiteralType(b.Type.FormatKind()), TypePropertyFlags.Required, "The kind of connection"),
                             new TypeProperty("source", LanguageConstants.String, TypePropertyFlags.Required, "The source of the connection"),
+                            new TypeProperty("role", roleType, TypePropertyFlags.None, "RBAC configuration to be applied on the connection"),
                         },
                         additionalPropertiesType: null,
                         additionalPropertiesFlags: TypePropertyFlags.None,


### PR DESCRIPTION
Update radius component data to support new connections kind "azure" and roles field for rbac permissions.
Detailed design: https://github.com/Azure/radius/issues/1321