### PR TITLE
Add secrets section for RabbitMQ component

### DIFF
--- a/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs
@@ -189,6 +189,21 @@ namespace Bicep.Core.TypeSystem.Radius.V3
         public static readonly BindingData BindingDataRabbitMQ = new BindingData()
         {
             Type = new ThreePartType("rabbitmq.com", "MessageQueue", RadiusResources.CategoryBinding),
+            Properties =
+            {
+                new TypeProperty(
+                    "secrets",
+                    new ObjectType(
+                        "secrets",
+                        validationFlags: TypeSymbolValidationFlags.WarnOnTypeMismatch,
+                        properties: new []
+                        {
+                            new TypeProperty("connectionString", LanguageConstants.String, TypePropertyFlags.WriteOnly),
+                        },
+                        additionalPropertiesType: null,
+                        additionalPropertiesFlags: TypePropertyFlags.None),
+                TypePropertyFlags.None),
+            },
             Values =
             {
                 new BindingValue("queue"),


### PR DESCRIPTION
Add `secrets` section for RabbitMQ component.

Part of https://github.com/Azure/radius/issues/1198. This allows `connectionString` to be specified by users using Bicep expression referring to K8s resources properties.
 