### PR TITLE
Revert to using full reference for K8s resources

### DIFF
--- a/src/Bicep.Core.IntegrationTests/KubernetesTests.cs
+++ b/src/Bicep.Core.IntegrationTests/KubernetesTests.cs
@@ -148,7 +148,7 @@ resource secret 'kubernetes.core/Secret@v1' = {
                     ["type"] = new JValue("Opaque"),
                     ["stringData"] = new JObject()
                     {
-                        ["key"] = new JValue("[reference(resourceId('kubernetes.core/ConfigMap', 'test-map')).data.key]")
+                        ["key"] = new JValue("[reference(resourceId('kubernetes.core/ConfigMap', 'test-map'), 'v1', 'full').properties.data.key]")
                     }
                 },
                 ["dependsOn"] = new JArray()
@@ -211,7 +211,7 @@ resource secret 'kubernetes.core/Secret@v1' = {
                     ["type"] = new JValue("Opaque"),
                     ["stringData"] = new JObject()
                     {
-                        ["key"] = new JValue("[reference(resourceId('kubernetes.core/ConfigMap', 'test-map')).data.key]")
+                        ["key"] = new JValue("[reference(resourceId('kubernetes.core/ConfigMap', 'test-map'), 'v1', 'full').properties.data.key]")
                     }
                 },
             });


### PR DESCRIPTION
This makes `rad-bicep` works with how we currently implement K8s Extension.